### PR TITLE
ci: fix publishing compatibility with npm

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   publish-release:
+    environment: npm-publish
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -19,7 +20,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-      - uses: MetaMask/action-publish-release@v2
+      - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install and build
@@ -28,11 +29,11 @@ jobs:
           npm run build
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v2
+        uses: MetaMask/action-npm-publish@v1.1.0
         env:
           SKIP_PREPACK: true
       - name: Publish
-        uses: MetaMask/action-npm-publish@v2
+        uses: MetaMask/action-npm-publish@v1.1.0
         with:
           # This `NPM_TOKEN` needs to be manually set per-repository.
           # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.


### PR DESCRIPTION
- `MetaMask/action-npm-publish@v2` assumes yarn - downgrade to `v1.1.0`
  - https://github.com/MetaMask/action-npm-publish/pull/17 
- Specify `npm-publish` environment
- Bump `MetaMask/action-publish-release` from `v2` to `v3`

---

#### Blocking
- #10